### PR TITLE
meta: add version to About

### DIFF
--- a/desk/desk.docket-0
+++ b/desk/desk.docket-0
@@ -1,7 +1,7 @@
 :~  title+'hodl'
     base+'hodl'
     color+0xb8.a3d1
-    glob-http+['https://globs.urbit.place/glob-0v7.u6i0a.uo2bg.qmdul.ppodi.dgk81.glob' 0v7.u6i0a.uo2bg.qmdul.ppodi.dgk81]
+    glob-http+['https://globs.urbit.place/glob-0vbk55s.8i1g8.amv47.kga6k.9gcr7.glob' 0vbk55s.8i1g8.amv47.kga6k.9gcr7]
     image+'https://user-images.githubusercontent.com/16504501/194947852-8802fd63-5954-4ce8-b147-2072bd929242.png'
     info+'A portfolio for all that you hodl'
     license+'MIT'

--- a/notes/setup.log
+++ b/notes/setup.log
@@ -14,3 +14,13 @@ sudo cp -rv ./desk/* ~/urbit/hodler/hodl/
 
 # on ship
 |commit %hodl
+
+
+# to update base dev / garden dev mime types
+# on hodler
+cd git/urbit
+sudo rsync -avL --delete ./pkg/base-dev/* ~/urbit/hodler/hodl
+sudo rsync -avL ./pkg/garden-dev/* ~/urbit/hodler/hodl
+cd
+cd git/hodl/
+sudo rsync -avL ./desk/* ~/urbit/hodler/hod

--- a/ui/index.html
+++ b/ui/index.html
@@ -16,6 +16,8 @@
       window.global = globalThis || window;
     </script>
     <title>%hodl</title>
+    <!-- code: https://github.com/tomholford/hodl -->
+    <!-- dist: |install ~hodler-datder-sonnet %hodl -->
   </head>
   <body>
     <noscript>This application requires Javascript to be enabled.</noscript>

--- a/ui/src/flags.ts
+++ b/ui/src/flags.ts
@@ -1,1 +1,4 @@
+import { version } from '../package.json';
+
 export const isDevelopment = import.meta.env.NODE_ENV === 'development';
+export const versionLabel = `${isDevelopment ? 'dev' : 'v'}${version}`;

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -20,7 +20,3 @@ root.render(
   </React.StrictMode>,
 
 );
-
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals

--- a/ui/src/views/About/About.tsx
+++ b/ui/src/views/About/About.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { ExternalLink } from "../Shared/ExternalLink"
 import './About.scss';
+
 import mauveWingUrl from '@/images/mauve-wing.png';
 import stellerfallUrl from '@/images/stellarfall.png';
+import { versionLabel } from '../../flags';
 
 export const About = () => {
   return (
@@ -36,6 +38,8 @@ export const About = () => {
         <li>~tocrex-holpen and ~mallus-fabres for artistic aesthetic</li>
         <li>~sarpen-laplux, ~hastuc-dibtux, and ~nocsyx-lassul for hoon expertise</li>
       </ul>
+      <h2>Version</h2>
+      <p><code>{versionLabel}</code></p>
     </div>
   )
 }


### PR DESCRIPTION
the purpose of this is to bump the glob hash since the previous update failed (the glob host was not serving new globs)